### PR TITLE
Removed code that uses a missed jQuery pluging

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -83,8 +83,3 @@ function LeerCookies() {
 function ActualizarCookies() {
     CrearCookie(inputHoraI,inputMinI,inputHoraF,inputMinF);
 }
-
-$('.clockpicker').clockpicker({
-    placement: 'bottom',
-    donetext: 'Listo'
-});


### PR DESCRIPTION
```
$('.clockpicker').clockpicker({
``` 
Its being used to create an instance of the clockpicker pluging over the html nodes with the css class clockpicker, but the plugin doesn't have been included into the project so it will fail breaking the rest of the javascript execution.